### PR TITLE
Use database instance directly and fix package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "cql-exec-fhir-mongo",
   "version": "1.0.0",
-  "description": "Provides a FHIR data provider for use with CQL",
-  "main": "index.js",
+  "description": "Provides a MongoDB-based data provider for use with CQL",
+  "main": "src/index.js",
   "scripts": {
     "lint": "eslint \"**/*.js\"",
     "lint:fix": "eslint \"**/*.js\" --fix",

--- a/src/fhir.js
+++ b/src/fhir.js
@@ -55,7 +55,6 @@ class PatientSource {
  */
 class Patient extends FHIRObject {
   constructor(patientData, modelInfo, mongoDb, shouldCheckProfile = false) {
-    // TODO: use connectionUrl to create instance of MongoClient
     const patientClass = modelInfo.patientClassIdentifier
       ? modelInfo.patientClassIdentifier
       : modelInfo.patientClassName;

--- a/test/fhir.test.js
+++ b/test/fhir.test.js
@@ -1,5 +1,5 @@
 const { PatientSource } = require('../src/fhir');
-const { testSetup, connection, testCleanup } = require('./setup');
+const { testSetup, db, testCleanup } = require('./setup');
 const { FHIRObject } = require('cql-exec-fhir');
 const testPatients = require('./fixtures/testPatients.json');
 const testProcedures = require('./fixtures/testProcedures.json');
@@ -11,7 +11,7 @@ describe('Patient Source', () => {
   beforeAll(async () => await testSetup(JSON.parse(JSON.stringify(testPatients))));
 
   test('Returns patient with current id on call to currentPatient()', async () => {
-    const ps = PatientSource.FHIRv401(connection);
+    const ps = PatientSource.FHIRv401(db);
     ps.loadPatientIds(TEST_PATIENT_IDS);
     const currentPatient = await ps.currentPatient();
     expect(ps._index).toEqual(0);
@@ -19,7 +19,7 @@ describe('Patient Source', () => {
   });
 
   test('Returns patient with next id on call to nextPatient()', async () => {
-    const ps = PatientSource.FHIRv401(connection);
+    const ps = PatientSource.FHIRv401(db);
     ps.loadPatientIds(TEST_PATIENT_IDS);
     const currentPatient = await ps.nextPatient();
     expect(ps._index).toEqual(1);
@@ -27,7 +27,7 @@ describe('Patient Source', () => {
   });
 
   test('Returns undefined on call to nextPatient() index is at end of patientIds array', async () => {
-    const ps = PatientSource.FHIRv401(connection);
+    const ps = PatientSource.FHIRv401(db);
     ps.loadPatientIds(TEST_PATIENT_IDS);
     await ps.nextPatient();
     const undef = await ps.nextPatient();
@@ -35,7 +35,7 @@ describe('Patient Source', () => {
   });
 
   test('Reset sets index back to 0', async () => {
-    const ps = PatientSource.FHIRv401(connection);
+    const ps = PatientSource.FHIRv401(db);
     ps.loadPatientIds(TEST_PATIENT_IDS);
     await ps.nextPatient();
     ps.reset();
@@ -48,7 +48,7 @@ describe('Patient Source', () => {
 describe('Patient', () => {
   beforeAll(async () => await testSetup(JSON.parse(JSON.stringify(ALL_TEST_RESOURCES))));
   test('findRecords on Procedure returns all valid procedure resources', async () => {
-    const ps = PatientSource.FHIRv401(connection);
+    const ps = PatientSource.FHIRv401(db);
     ps.loadPatientIds(TEST_PATIENT_IDS);
     const patient = await ps.currentPatient();
     const records = await patient.findRecords('Procedure');
@@ -62,7 +62,7 @@ describe('Patient', () => {
   });
 
   test('findRecords on Procedure correctly returns no resources when no Procedure resources reference patient', async () => {
-    const ps = PatientSource.FHIRv401(connection);
+    const ps = PatientSource.FHIRv401(db);
     ps.loadPatientIds(TEST_PATIENT_IDS);
     const patient = await ps.nextPatient();
     const records = await patient.findRecords('Procedure');
@@ -71,7 +71,7 @@ describe('Patient', () => {
   });
 
   test('findRecords on Library correctly returns all Libraries', async () => {
-    const ps = PatientSource.FHIRv401(connection);
+    const ps = PatientSource.FHIRv401(db);
     ps.loadPatientIds(TEST_PATIENT_IDS);
     const patient = await ps.currentPatient();
     const records = await patient.findRecords('Library');
@@ -80,7 +80,7 @@ describe('Patient', () => {
   });
 
   test('findRecords on Patient returns the patient', async () => {
-    const ps = PatientSource.FHIRv401(connection);
+    const ps = PatientSource.FHIRv401(db);
     ps.loadPatientIds(TEST_PATIENT_IDS);
     const patient = await ps.currentPatient();
     const records = await patient.findRecords('Patient');

--- a/test/setup.js
+++ b/test/setup.js
@@ -34,4 +34,4 @@ const convertToFhirObjects = (data, klass, modelInfo) => {
   return data.map(d => new FHIRObject(d, classInfo, modelInfo));
 };
 
-module.exports = { testSetup, testCleanup, connection, convertToFhirObjects };
+module.exports = { testSetup, testCleanup, db, convertToFhirObjects };


### PR DESCRIPTION
# Summary

This does some fix ups to make this package actually work as an external dependency.

## New behavior

None really except that it works as a dependency now

## Code changes

* Fix `package.json` to properly point to `src/index.js` 
* Update the Patient source to use a mongo `db` instance, not just the client. Before, the code was calling `client.db().collection` which was creating a new database during execution rather than using the proper database provided by the client.

# Testing guidance

* tests
* Best going to be tested in an upcoming deqm-test-server PR 
